### PR TITLE
allow updating shared state in SharedWrapper

### DIFF
--- a/shared/links.js
+++ b/shared/links.js
@@ -1,8 +1,13 @@
 import Link from "next/link";
+import { useCallback } from "react";
 import { useSharedContext } from "./wrapper";
 
 export default function Links() {
-  const sharedContext = useSharedContext();
+  const { sharedState, setSharedState } = useSharedContext();
+  const clickHandler = useCallback(() => {
+    setSharedState(Math.random());
+  }, []);
+
   return (
     <div style={{ display: "flex", flexDirection: "column", margin: 20 }}>
       <Link href="/">
@@ -14,7 +19,8 @@ export default function Links() {
       <Link href="/notshared">
         <a>Not shared</a>
       </Link>
-      {sharedContext}
+      {sharedState}
+      <button onClick={clickHandler}>Update shared state</button>
     </div>
   );
 }

--- a/shared/wrapper.js
+++ b/shared/wrapper.js
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect } from "react";
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
 
 const Context = createContext("Missing context!");
 
@@ -7,11 +7,22 @@ export function useSharedContext() {
 }
 
 export default function SharedWrapper({ children }) {
+  const [sharedState, setSharedState] = useState("Shared normal React state");
+  const sharedStateObject = useMemo(
+    () => ({
+      sharedState,
+      setSharedState,
+    }),
+    [sharedState]
+  );
+
   useEffect(() => {
     console.log("SharedWrapper mounted");
 
     return () => console.log("SharedWrapper unmounted");
   });
 
-  return <Context.Provider value="Context!">{children}</Context.Provider>;
+  return (
+    <Context.Provider value={sharedStateObject}>{children}</Context.Provider>
+  );
 }


### PR DESCRIPTION
This expands the example a bit, by defining some state in `SharedWrapper` and passing it and its state updater function via the context.

Pages that share state can now each update the shared state.